### PR TITLE
Discard long log lines when processing cloud-init-output.log

### DIFF
--- a/fluentbit/fluentbit.conf
+++ b/fluentbit/fluentbit.conf
@@ -2,6 +2,7 @@
     Name tail
     Path /var/log/cloud-init-output.log
     Read_from_Head true
+    Skip_Long_Lines true
     Tag cloud-init-output
     Key message
 

--- a/fluentbit/fluentbit.test.conf
+++ b/fluentbit/fluentbit.test.conf
@@ -2,6 +2,7 @@
     Name tail
     Path /var/log/cloud-init-output.log
     Read_from_Head true
+    Skip_Long_Lines true
     Tag cloud-init-output
     Key message
 


### PR DESCRIPTION
## What does this change?

Whilst testing this role with Amigo (see https://github.com/guardian/amigo/pull/719), I noticed that the initial part of `cloud-init-output.log` was being reprocessed _repeatedly_, but the end of the file was _never_ processed. This led to thousands of duplicate log lines in ELK.

After connecting to an affected instance and checking the status of `fluentbit`, I noticed a lot of errors like:
```file=/var/log/cloud-init-output.log requires a larger buffer size, lines are too long. Skipping file.```

I think the problematic log line was the (huge) output of a file being downloaded from S3.

In order to avoid this problem, this PR [tells `fluentbit` to drop log lines that are too large to process](https://docs.fluentbit.io/manual/pipeline/inputs/tail/#config).

## How to test

I manually added this line to the config (directly on the instance) and restarted `fluentbit`. I was able to confirm that a) the problematic log line was skipped and b) the rest of the file was successfully processed.

## How can we measure success?

We should stop seeing duplicate `cloud-init-output` log lines for Amigo once this change has been deployed and baked into the AMI.

## Have we considered potential risks?

Yes, it's possible that this change will cause us to drop a long line which contains some important data and this could confuse users. In practice, I think extremely large log lines would also be dropped on the ELK side (i.e. Logstash would refuse to process them).

We could consider [increasing the buffer size as well (or instead)](https://docs.fluentbit.io/manual/pipeline/inputs/tail/#config), if we are concerned about dropping these very long lines?
