### PR TITLE
Add basic application log shipping

### DIFF
--- a/fluentbit/application-logs.conf
+++ b/fluentbit/application-logs.conf
@@ -1,0 +1,15 @@
+[INPUT]
+    Name systemd
+    Systemd_Filter _SYSTEMD_UNIT={{SYSTEMD_UNIT}}
+    Strip_Underscores true
+    Tag application-logs
+
+[FILTER]
+    Name record_modifier
+    Match application-logs
+    Allowlist_key MESSAGE
+
+[FILTER]
+    Name modify
+    Match application-logs
+    Rename MESSAGE message

--- a/fluentbit/test-configs/application-logs.test.conf
+++ b/fluentbit/test-configs/application-logs.test.conf
@@ -1,0 +1,15 @@
+[INPUT]
+    Name systemd
+    Systemd_Filter _SYSTEMD_UNIT=bar.service
+    Strip_Underscores true
+    Tag application-logs
+
+[FILTER]
+    Name record_modifier
+    Match application-logs
+    Allowlist_key MESSAGE
+
+[FILTER]
+    Name modify
+    Match application-logs
+    Rename MESSAGE message

--- a/fluentbit/test-configs/fluentbit-cloud-init-and-app.test.conf
+++ b/fluentbit/test-configs/fluentbit-cloud-init-and-app.test.conf
@@ -10,15 +10,20 @@
     Name modify
     Match cloud-init-output
     Add Source cloud-init-output
-{{APPLICATION_LOGS}}
+
+@INCLUDE application-logs.conf
+
 [FILTER]
     Name modify
     Match *
     Add ShippedBy devx-logs
-    {{TAGS}}
+    Add SystemdUnit bar.service
+    Add app bar
+    Add stack test
+    Add stage CODE
 
 [OUTPUT]
     Name kinesis_streams
     Match *
     region eu-west-1
-    stream {{KINESIS_STREAM}}
+    stream foo

--- a/fluentbit/test-configs/fluentbit-cloud-init-only.test.conf
+++ b/fluentbit/test-configs/fluentbit-cloud-init-only.test.conf
@@ -8,8 +8,12 @@
 
 [FILTER]
     Name modify
+    Match cloud-init-output
+    Add Source cloud-init-output
+
+[FILTER]
+    Name modify
     Match *
-    Add Source cloud-init
     Add ShippedBy devx-logs
     Add app bar
     Add stack test


### PR DESCRIPTION
## What does this change?

This PR adds basic application log shipping functionality. Currently everything in the message field will be forwarded to ELK as a single field. This means that, for example, we won't currently parse structured/JSON logs and send individual fields to ELK. I suggest that we add this in the next PR.

Application log shipping will be configured if the relevant tag (`SystemdUnit`) is present on instances. If the tag is omitted, `cloud-init-output.log` shipping will still be configured. This allows users to decouple their adoption of the `cloud-init-output.log` shipping feature from their adoption of application log shipping (using this new approach). 

This is useful because `cloud-init-output.log` shipping is a new feature (to the best of my knowledge, no other teams ship these logs yet) and we want teams to adopt it immediately. However most teams have already configured application logging via some other means; moving to this new approach will likely involve some code changes and we don't need teams to prioritise this immediately, so we allow them to opt-in (via the tag) when they are ready.

## How to test

See https://github.com/guardian/amiable/pull/127.

## How can we measure success?

We have a very basic version of automated application log shipping.

## Have we considered potential risks / drawbacks?

I think this is low risk as we are still experimenting with this AMIgo role and it should not impact existing functionality.