### PR TITLE
Upload artifacts to Riff-Raff for all branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,6 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     needs: [test]
-    if: github.ref == 'refs/heads/main'
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:


### PR DESCRIPTION
I think it's safe to do this as we only have CD configured for the `main` branch:

![image](https://user-images.githubusercontent.com/19384074/165104185-c6ef30df-c253-4d3b-bbc7-ec7b43db914a.png)

