### PR TITLE
Include instance ID in log records for easier debugging

### DIFF
--- a/fluentbit/fluentbit.conf
+++ b/fluentbit/fluentbit.conf
@@ -17,6 +17,15 @@
     Add ShippedBy devx-logs
     {{TAGS}}
 
+[FILTER]
+    Name aws
+    Match *
+    imds_version v2
+    az true
+    ec2_instance_id true
+    ami_id true
+    vpc_id true
+
 [OUTPUT]
     Name kinesis_streams
     Match *

--- a/fluentbit/test-configs/fluentbit-cloud-init-and-app.test.conf
+++ b/fluentbit/test-configs/fluentbit-cloud-init-and-app.test.conf
@@ -22,6 +22,15 @@
     Add stack test
     Add stage CODE
 
+[FILTER]
+    Name aws
+    Match *
+    imds_version v2
+    az true
+    ec2_instance_id true
+    ami_id true
+    vpc_id true
+
 [OUTPUT]
     Name kinesis_streams
     Match *

--- a/fluentbit/test-configs/fluentbit-cloud-init-only.test.conf
+++ b/fluentbit/test-configs/fluentbit-cloud-init-only.test.conf
@@ -19,6 +19,15 @@
     Add stack test
     Add stage CODE
 
+[FILTER]
+    Name aws
+    Match *
+    imds_version v2
+    az true
+    ec2_instance_id true
+    ami_id true
+    vpc_id true
+
 [OUTPUT]
     Name kinesis_streams
     Match *

--- a/main_test.go
+++ b/main_test.go
@@ -36,12 +36,12 @@ func TestGenerateConfigs(t *testing.T) {
 	cloudInitWithInclude, _ := os.ReadFile("fluentbit/test-configs/fluentbit-cloud-init-and-app.test.conf")
 	application, _ := os.ReadFile("fluentbit/test-configs/application-logs.test.conf")
 
-	withoutApplicationLogs := FluentbitConfig { MainConfigFile: string(cloudInitOnly) }
-    withApplicationLogs := FluentbitConfig { MainConfigFile: string(cloudInitWithInclude), ApplicationConfigFile: string(application) }
+	withoutApplicationLogs := FluentbitConfig{MainConfigFile: string(cloudInitOnly)}
+	withApplicationLogs := FluentbitConfig{MainConfigFile: string(cloudInitWithInclude), ApplicationConfigFile: string(application)}
 
 	var tests = []struct {
 		tagsArg string
-		want FluentbitConfig
+		want    FluentbitConfig
 	}{
 		{"app=bar,stack=test,stage=CODE", withoutApplicationLogs},
 		{"app=bar,stack=test,stage=CODE,SystemdUnit=bar.service", withApplicationLogs},
@@ -49,6 +49,7 @@ func TestGenerateConfigs(t *testing.T) {
 
 	for _, testCase := range tests {
 		got := generateConfigs(testCase.tagsArg, "foo")
+
 		if got.MainConfigFile != testCase.want.MainConfigFile {
 			t.Error(diff.Diff(got.MainConfigFile, testCase.want.MainConfigFile))
 		}


### PR DESCRIPTION
Without the instance ID, debugging startup and other issues that are specific to an instance becomes difficult as instance logs are interleaved.

Unfortunately, this introduces a blocking IMDS call, which would have been nice to avoid. But instance-tag-discovery doesn't quite seem the right place either. Thoughts welcome.