### PR TITLE
Update application log shipping status

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The `cdk-base` Amigo role uses this to provide log shipping out of the box.
 The following logs are supported:
 
 - [x] cloud-init
-- [ ] application logs (PLANNED FOR THE NEAR FUTURE)
+- [ ] application logs (currently being beta tested with DevX applications - we hope to add full support for this soon!)
 
 Use the `-h` flag for more info.
 


### PR DESCRIPTION
## What does this change?

Just bringing the README up to date following https://github.com/guardian/devx-logs/pull/11, as our colleagues may be viewing this repo due to @nicl's recent feature announcement. 

I have deliberately avoided mentioning it in the [Amigo role](https://github.com/guardian/amigo/tree/main/roles/cdk-base) for now, as we don't want teams to start using this feature yet.
