### PR TITLE
fix: Docker image publishing

### DIFF
--- a/.github/workflows/ecs-publish.yaml
+++ b/.github/workflows/ecs-publish.yaml
@@ -11,7 +11,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: devx-logs-for-ecs
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
## What does this change?
When publishing to GitHub Packages, the image name should match the repository name.