### PR TITLE
[docs] fix missing IAM action `kinesis:PutRecords`

### DIFF
--- a/ec2/README.md
+++ b/ec2/README.md
@@ -25,7 +25,7 @@ Usage:
 Flags:
       --dry-run                    Set to true to print config to stdout rather than write to file.
   -h, --help                       help for devx-logs
-      --kinesisStreamName string   Typically configured via a 'LogKinesisStreamName' tag on the instance, but you can override using this flag. To write to Kinesis, your instance will need the following permissions for this stream: kinesis:DescribeStream, kinesis:PutRecord.
+      --kinesisStreamName string   Typically configured via a 'LogKinesisStreamName' tag on the instance, but you can override using this flag. To write to Kinesis, your instance will need the following permissions for this stream: kinesis:DescribeStream, kinesis:PutRecord AND kinesis:PutRecords.
       --tags string                Typically read from /etc/config/tags.json (see Amigo's cdk-base role here for more info), but you can override using this flag. Pass a comma-separated list of Key=Value pairs, to be included on log records.
 ```
 


### PR DESCRIPTION
When working on https://github.com/guardian/editorial-tools-platform/pull/703 / https://github.com/guardian/targeting/pull/183 nothing was shipping to ELK and we noticed the following in td-agent-bit's own log output... 
![image](https://github.com/guardian/devx-logs/assets/19289579/83ed3c2b-d26d-4492-a77d-3f38a87bcdc3)
...turns out we were missing `kinesis:PutRecords` in our IAM policy.

This PR corrects the documentation to cover all three required IAM actions.