### PR TITLE
feat(ecs): Add `name` marker to logs

### DIFF
--- a/ecs/guardian.conf
+++ b/ecs/guardian.conf
@@ -17,3 +17,4 @@
     Add stage ${STAGE}
     Add app ${APP}
     Add gu:repo ${GU_REPO}
+    Add name ${NAME}


### PR DESCRIPTION
## What does this change?
Add a `name` marker to the logs from ECS. This helps to identify the logs a bit more easily.

The markers added in #34 also allow for this, but at a specific revision. For example `ServiceCatalogueCODECloudquerySourceOrgWideCloudFormationTaskDefinitionC836C4B8:19`.

