### PR TITLE
Bump `actions-riff-raff` to V4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,9 +41,10 @@ jobs:
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
-      # required by aws-actions/configure-aws-credentials
+      # required by guardian/actions-riff-raff@v4
       id-token: write
       contents: read
+      pull-requests: write # required since guardian/actions-riff-raff@v3
 
     steps:
       - uses: actions/checkout@v3
@@ -57,13 +58,11 @@ jobs:
           GOOS=linux GOARCH=arm64 go build -o $BINARY_NAME-arm64 main.go
           GOOS=linux GOARCH=amd64 go build -o $BINARY_NAME-amd64 main.go
 
-      - uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-      - uses: guardian/actions-riff-raff@v2
+      - uses: guardian/actions-riff-raff@v4
         with:
           app: devx-logs
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           contentDirectories: |
             devx-logs:
               - ec2/${{ env.BINARY_NAME }}-arm64


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Upgrade [guardian/actions-riff-raff](https://github.com/guardian/actions-riff-raff) to [v4](https://github.com/guardian/actions-riff-raff/releases/tag/v4).

## Why?

This allows us to remove the [aws-configure-credentials](https://github.com/aws-actions/configure-aws-credentials) step from the earlier part of the workflow.
See [`actions-riff-raff` change](https://github.com/guardian/actions-riff-raff/pull/108) for details.
