### PR TITLE
Add `volume` directive to ECS Dockerfile

### DIFF
--- a/ecs/Dockerfile
+++ b/ecs/Dockerfile
@@ -14,3 +14,5 @@ ENV aws_fluent_bit_init_file_3 /guardian.conf
 
 ADD guardian-parsers.conf /guardian-parsers.conf
 ADD guardian.conf /guardian.conf
+
+VOLUME [ "/init" ]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

AWS FSBP [ECS.5](https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html#ecs-5) states that root container filesystems must be readonly. We can specify particular directories as exceptions to this by using ephemeral volumes such as bind mounts. Specifying a `VOLUME` in the Dockerfile, means that when we intantiate a container using this image, we can set the directory specified by the `VOLUME` command as a mount point, [and it's contents will not be erased](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html).

## How to test

We have tested this by running this container with a mount point at `/init`, and have verified that it is able to run as normal, indicating the files were not destroyed when the volume was mounted.


## How can we measure success?

We see fewer ECS.5 failures, as we no longer need root filesystem write access to make changes to the `/init` folder
