### PR TITLE
Add level and logger-name tags

### DIFF
--- a/ec2/fluentbit/fluentbit.conf
+++ b/ec2/fluentbit/fluentbit.conf
@@ -13,6 +13,8 @@
     Name modify
     Match cloud-init-output
     Add Source cloud-init-output
+    Add level INFO
+    Add logger_name cloud-init-output
 {{APPLICATION_LOGS}}
 [FILTER]
     Name modify

--- a/ec2/fluentbit/test-configs/fluentbit-cloud-init-and-app.test.conf
+++ b/ec2/fluentbit/test-configs/fluentbit-cloud-init-and-app.test.conf
@@ -13,6 +13,8 @@
     Name modify
     Match cloud-init-output
     Add Source cloud-init-output
+    Add level INFO
+    Add logger_name cloud-init-output
 
 @INCLUDE application-logs.conf
 

--- a/ec2/fluentbit/test-configs/fluentbit-cloud-init-only.test.conf
+++ b/ec2/fluentbit/test-configs/fluentbit-cloud-init-only.test.conf
@@ -13,6 +13,8 @@
     Name modify
     Match cloud-init-output
     Add Source cloud-init-output
+    Add level INFO
+    Add logger_name cloud-init-output
 
 [FILTER]
     Name modify


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

In the availability dashboard, we filter logs by level, and expose the `logger_name` property for filtering. This is very handy for application logs, however, cloud-init-output logs don't have these tags, which means they aren't surfaced in the dashboard. It would be handy for the logs to be exposed, as it can help debug why instances are unhealthy (that can easily trigger SLO alerts)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I've tested this approach by creating the conf files locally based on `tags.json` with `./devx-logs --dry-run --kinesisStreamName <real id>` and then manually patching a live box via ssh. It looks like it works!

### Before

https://logs.gutools.co.uk/s/devx/app/r/s/ci6vb

<img width="1167" height="173" alt="Screenshot 2026-01-23 at 17 59 49" src="https://github.com/user-attachments/assets/f34e191e-e975-46ef-963d-cedda1aa4cf6" />


### After

https://logs.gutools.co.uk/s/devx/app/r/s/bIdSd

<img width="1159" height="163" alt="Screenshot 2026-01-23 at 18 00 31" src="https://github.com/user-attachments/assets/f561d4e4-0245-4a9a-83c4-7a1233744360" />



<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
