### PR TITLE
chore: Update Go version 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: "1.17"
       - name: Run tests
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: "1.17"
       - name: Build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.17"
+          go-version-file: ec2/go.mod
       - name: Run tests
         working-directory: ec2
         run: go test .
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.17"
+          go-version-file: ec2/go.mod
       - name: Build
         working-directory: ec2
         run: |

--- a/ec2/go.mod
+++ b/ec2/go.mod
@@ -1,6 +1,6 @@
 module github.com/guardian/devx-logs
 
-go 1.17
+go 1.26.4
 
 require (
 	github.com/kylelemons/godebug v1.1.0


### PR DESCRIPTION
## What does this change?
For the same reasons as https://github.com/guardian/instance-tag-discovery/pull/30, this change updates the version of Go after noticing an AWS Inspector finding against `go/stdlib`. Inspector suggests updating to at least 1.25.10.

## How has this change been tested?
There are a few things to check here.

1. Does `actions/setup-go` install the correct version?

    To check, we can look at the build log:
    <img width="333" height="510" alt="image" src="https://github.com/user-attachments/assets/4e8a0d73-d401-4973-a6e3-fb3c3fc5ac55" />

2. Does the binary use the go/stdlib at version 1.25.10?

    To test this, we can download the [build artifacts from RIff-Raff](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=deploy%3A%3Adevx-logs&id=181) and check:

    ```console
    ❯ go version -m devx-logs-linux-amd64
    devx-logs-linux-amd64: go1.26.4
    
    ❯ go version -m devx-logs-linux-arm64
    devx-logs-linux-arm64: go1.26.4
    ```

3. Does the binary produce the runtime output? To test this, I:

    - Copied the artifact from Riff-Raff's bucket to a place accessible by https://github.com/guardian/cdk-playground:

    ```console
    aws s3 cp \
      s3://<RIFF_RAFF_BUCKET>/deploy::devx-logs/181/devx-logs/devx-logs-linux-arm64 \
      s3://<DIST_BUCKET>/deploy/CODE/cdk-playground/devx-logs-linux-arm64 \
      --profile deployTools
    ```

   - Connected to an EC2 instance of https://github.com/guardian/cdk-playground:
   
    ```console
    ssm ssh --profile deployTools -t cdk-playground,deploy,CODE -x
    ```

   - Downloaded the new binary:

    ```console
    aws s3 cp s3://<DIST_BUCKET>/deploy/CODE/cdk-playground/devx-logs-linux-arm64 .
    sudo chmod u+x devx-logs-linux-arm64
    ```

   - Deleted the existing runtime output:

    ```console
    sudo rm /etc/td-agent-bit/application-logs.conf
    sudo rm /etc/td-agent-bit/td-agent-bit.conf
    ```

   - Ran the new binary and saw the new runtime output:

    ```console
    sudo ./devx-logs-linux-arm64
    ```

    ```console
    ls -lah /etc/td-agent-bit/
    
    total 28K
    drwxr-xr-x  2 root root 4.0K Jun  5 07:24 .
    drwxr-xr-x 99 root root 4.0K Jun  4 08:50 ..
    -rw-r--r--  1 root root  391 Jun  5 07:24 application-logs.conf
    -rw-r--r--  1 root root 4.6K Nov 27  2022 parsers.conf
    -rw-r--r--  1 root root   45 Nov 27  2022 plugins.conf
    -rw-r--r--  1 root root 1.7K Jun  5 07:24 td-agent-bit.conf
    ```

4. Is the Inspector finding resolved?
    This one is quite involved and can only be understood once we've merged, baked a new AMI and brought that AMI into service. Once complete we can use the following [query in Service Catalogue](https://metrics.gutools.co.uk/goto/cfo73jit59s74f?orgId=1) to confirm:

    ```sql
    WITH data AS (
      SELECT  aws_account_id
              , finding_arn
              , first_observed_at
              , res ->> 'Type' AS resource_type
              , res ->> 'Id' AS resource_id
              , res -> 'Tags' ->> 'Stack' AS stack
              , res -> 'Tags' ->> 'Stage' AS stage
              , res -> 'Tags' ->> 'App' AS app
              , res -> 'Tags' ->> 'gu:repo' AS repo
              , res ->> 'Tags' AS tags
              , vulnerable_packages ->> 'FilePath' AS file_path
      FROM    aws_inspector2_findings 
              , JSONB_ARRAY_ELEMENTS(package_vulnerability_details -> 'VulnerablePackages') AS vulnerable_packages
              , JSONB_ARRAY_ELEMENTS(resources) AS res
    )
    
    SELECT  DISTINCT
            stack
            , stage
            , app
            , repo
    FROM    data 
    WHERE   file_path LIKE '%01-devx-logs'
    ````